### PR TITLE
update for 1.0.0rc2 in which Record.record?/2 was removed

### DIFF
--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -258,17 +258,21 @@ defmodule SweetXml do
 
   defp _value(entity) do
     cond do
-      Record.record? entity, :xmlText ->
+      is_record? entity, :xmlText ->
         xmlText(entity, :value)
-      Record.record? entity, :xmlComment ->
+      is_record? entity, :xmlComment ->
         xmlComment(entity, :value)
-      Record.record? entity, :xmlPI ->
+      is_record? entity, :xmlPI ->
         xmlPI(entity, :value)
-      Record.record? entity, :xmlAttribute ->
+      is_record? entity, :xmlAttribute ->
         xmlAttribute(entity, :value)
       true ->
         entity
     end
+  end
+
+  defp is_record?(data, kind) do
+    is_tuple(data) and tuple_size(data) > 0 and :erlang.element(1, data) == kind
   end
 
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule SweetXml.Mixfile do
     [
       app: :sweet_xml,
       version: "0.1.0",
-      elixir: "~> 0.14.2",
+      elixir: "~> 1.0.0-rc2",
       deps: deps,
       package: [
         contributors: ["Frank Liu"],


### PR DESCRIPTION
Record.record?/1 and /2 were removed in Elixir 1.0.0rc2. I added a private method with relevant functionality from the deprecated function.

Original Record.record?/2 for reference:

``` elixir
@doc false
defmacro record?(data, kind) do
  case Macro.Env.in_guard?(__CALLER__) do
    true ->
      quote do
        is_tuple(unquote(data)) and tuple_size(unquote(data)) > 0
          and :erlang.element(1, unquote(data)) == unquote(kind)
      end
    false ->
      quote do
        result = unquote(data)
        is_tuple(result) and tuple_size(result) > 0
          and :erlang.element(1, result) == unquote(kind)
      end
  end
end
```
