### PR TITLE
Update mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule SweetXml.Mixfile do
       app: :sweet_xml,
       version: "0.6.3",
       elixir: "~> 1.0",
-      deps: deps,
+      deps: deps(),
       package: [
         maintainers: ["Frank Liu", "Arnaud Wetzel", "Tomáš Brukner", "Vinícius Sales", "Sean Tan"],
         licenses: ["MIT"],


### PR DESCRIPTION
Update mix.exs in order to get rid of Elixir 1.4 warnings.