### PR TITLE
Fix spacing issue for the transform_by examples.

### DIFF
--- a/doc/404.html
+++ b/doc/404.html
@@ -5,7 +5,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="ExDoc v0.14.5">
-    <title>404 – sweet_xml v0.6.4</title>
+    <title>404 – sweet_xml v0.6.5</title>
     <link rel="stylesheet" href="dist/app-a07cea761b.css" />
     
     <script src="dist/sidebar_items-717acc2310.js"></script>
@@ -26,7 +26,7 @@
         sweet_xml
       </h1>
       <h2 class="sidebar-projectVersion">
-        v0.6.4
+        v0.6.5
       </h2>
     </div>
     

--- a/doc/SweetXml.html
+++ b/doc/SweetXml.html
@@ -5,7 +5,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="ExDoc v0.14.5">
-    <title>SweetXml – sweet_xml v0.6.4</title>
+    <title>SweetXml – sweet_xml v0.6.5</title>
     <link rel="stylesheet" href="dist/app-a07cea761b.css" />
     
     <script src="dist/sidebar_items-717acc2310.js"></script>
@@ -26,7 +26,7 @@
         sweet_xml
       </h1>
       <h2 class="sidebar-projectVersion">
-        v0.6.4
+        v0.6.5
       </h2>
     </div>
     
@@ -58,7 +58,7 @@
 
 
       <h1>
-        <small class="visible-xs">sweet_xml v0.6.4</small>
+        <small class="visible-xs">sweet_xml v0.6.5</small>
         SweetXml
         
         
@@ -652,19 +652,19 @@ iex&gt; SweetXml.stream_tags(doc, :header, discard: [:title])
   Examples
 </h2>
 
-<p>  iex&gt; import SweetXml
-  iex&gt; string_to_range = fn str -&gt;
-  …&gt;     [first, last] = str |&gt; String.split(“-“, trim: true) |&gt; Enum.map(&amp;String.to_integer/1)
-  …&gt;     first..last
-  …&gt;   end
-  iex&gt; doc = “<weather><zone><name>north</name><wind-speed>5-15</wind-speed></zone></weather>”
-  iex&gt; doc
-  …&gt; |&gt; xpath(
-  …&gt;      ~x”//weather/zone”l,
-  …&gt;      name: ~x”//name/text()”s |&gt; transform_by(&amp;String.capitalize/1),
-  …&gt;      wind_speed: ~x”./wind-speed/text()”s |&gt; transform_by(string_to_range)
-  …&gt;    )
-  [%{name: “North”, wind_speed: 5..15}]</p>
+<pre><code class="iex elixir">iex&gt; import SweetXml
+iex&gt; string_to_range = fn str -&gt;
+...&gt;     [first, last] = str |&gt; String.split(&quot;-&quot;, trim: true) |&gt; Enum.map(&amp;String.to_integer/1)
+...&gt;     first..last
+...&gt;   end
+iex&gt; doc = &quot;&lt;weather&gt;&lt;zone&gt;&lt;name&gt;north&lt;/name&gt;&lt;wind-speed&gt;5-15&lt;/wind-speed&gt;&lt;/zone&gt;&lt;/weather&gt;&quot;
+iex&gt; doc
+...&gt; |&gt; xpath(
+...&gt;      ~x&quot;//weather/zone&quot;l,
+...&gt;      name: ~x&quot;//name/text()&quot;s |&gt; transform_by(&amp;String.capitalize/1),
+...&gt;      wind_speed: ~x&quot;./wind-speed/text()&quot;s |&gt; transform_by(string_to_range)
+...&gt;    )
+[%{name: &quot;North&quot;, wind_speed: 5..15}]</code></pre>
 
   </section>
 </div>

--- a/doc/SweetXpath.html
+++ b/doc/SweetXpath.html
@@ -5,7 +5,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="ExDoc v0.14.5">
-    <title>SweetXpath – sweet_xml v0.6.4</title>
+    <title>SweetXpath – sweet_xml v0.6.5</title>
     <link rel="stylesheet" href="dist/app-a07cea761b.css" />
     
     <script src="dist/sidebar_items-717acc2310.js"></script>
@@ -26,7 +26,7 @@
         sweet_xml
       </h1>
       <h2 class="sidebar-projectVersion">
-        v0.6.4
+        v0.6.5
       </h2>
     </div>
     
@@ -58,7 +58,7 @@
 
 
       <h1>
-        <small class="visible-xs">sweet_xml v0.6.4</small>
+        <small class="visible-xs">sweet_xml v0.6.5</small>
         SweetXpath
         
         

--- a/doc/api-reference.html
+++ b/doc/api-reference.html
@@ -5,7 +5,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="ExDoc v0.14.5">
-    <title>API Reference – sweet_xml v0.6.4</title>
+    <title>API Reference – sweet_xml v0.6.5</title>
     <link rel="stylesheet" href="dist/app-a07cea761b.css" />
     
     <script src="dist/sidebar_items-717acc2310.js"></script>
@@ -26,7 +26,7 @@
         sweet_xml
       </h1>
       <h2 class="sidebar-projectVersion">
-        v0.6.4
+        v0.6.5
       </h2>
     </div>
     
@@ -58,7 +58,7 @@
 
 
 <h1>
-  <small class="visible-xs">sweet_xml v0.6.4</small>
+  <small class="visible-xs">sweet_xml v0.6.5</small>
   API Reference
 </h1>
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>sweet_xml v0.6.4 – Documentation</title>
+    <title>sweet_xml v0.6.5 – Documentation</title>
     <meta http-equiv="refresh" content="0; url=api-reference.html">
     <meta name="robots" content="noindex">
     <meta name="generator" content="ExDoc v0.14.5">

--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -35,8 +35,7 @@ defmodule SweetXml do
       optionally "discard" some dom elements in order to free memory during
       streaming for big files which cannot fit entirely in memory
 
-  ## Examples
-
+  ## Examples 
   Simple Xpath
 
       iex> import SweetXml
@@ -536,19 +535,19 @@ defmodule SweetXml do
 
   ## Examples
 
-    iex> import SweetXml
-    iex> string_to_range = fn str ->
-    ...>     [first, last] = str |> String.split("-", trim: true) |> Enum.map(&String.to_integer/1)
-    ...>     first..last
-    ...>   end
-    iex> doc = "<weather><zone><name>north</name><wind-speed>5-15</wind-speed></zone></weather>"
-    iex> doc
-    ...> |> xpath(
-    ...>      ~x"//weather/zone"l,
-    ...>      name: ~x"//name/text()"s |> transform_by(&String.capitalize/1),
-    ...>      wind_speed: ~x"./wind-speed/text()"s |> transform_by(string_to_range)
-    ...>    )
-    [%{name: "North", wind_speed: 5..15}]
+      iex> import SweetXml
+      iex> string_to_range = fn str ->
+      ...>     [first, last] = str |> String.split("-", trim: true) |> Enum.map(&String.to_integer/1)
+      ...>     first..last
+      ...>   end
+      iex> doc = "<weather><zone><name>north</name><wind-speed>5-15</wind-speed></zone></weather>"
+      iex> doc
+      ...> |> xpath(
+      ...>      ~x"//weather/zone"l,
+      ...>      name: ~x"//name/text()"s |> transform_by(&String.capitalize/1),
+      ...>      wind_speed: ~x"./wind-speed/text()"s |> transform_by(string_to_range)
+      ...>    )
+      [%{name: "North", wind_speed: 5..15}]
   """
   def transform_by(%SweetXpath{}=sweet_xpath, fun) when is_function(fun) do
     %{sweet_xpath | transform_fun: fun}


### PR DESCRIPTION
I moved the examples over another 2 spaces so they would be formatted correct when generating the HTML.