### PR TITLE
Optional strings should return nil, not empty string

### DIFF
--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -433,7 +433,10 @@ defmodule SweetXml do
     spec = %SweetXpath{spec | is_list: true}
     get_current_entities(parent, spec)
     |> Enum.map(&(_value(&1) |> to_cast(string_type, is_opt?)))
-    |> Enum.join
+    |> case do
+      [] -> nil
+      items -> Enum.join(items)
+    end
     |> spec.transform_fun.()
   end
 

--- a/test/sweet_xml_test.exs
+++ b/test/sweet_xml_test.exs
@@ -419,6 +419,13 @@ defmodule SweetXmlTest do
     assert xpath(doc, ~x[/fantasy_content/league/league_id/text()])  == '239541'
     assert xpath(doc, ~x[/fantasy_content/league/league_id/text()]s) == "239541"
     assert xpath(doc, ~x[/fantasy_content/league/league_id/text()]i) ==  239541
+    assert xpath(doc, ~x[/fantasy_content/league/short_invitation_url/text()]) ==  nil
+    assert xpath(doc, ~x[/fantasy_content/league/short_invitation_url/text()]o) ==  nil
+    assert xpath(doc, ~x[/fantasy_content/league/short_invitation_url/text()]os) ==  nil
+    assert xpath(doc, ~x[/fantasy_content/league/short_invitation_url/text()]oS) ==  nil
+    assert xpath(doc, ~x[/fantasy_content/idontexist/text()]o) ==  nil
+    assert xpath(doc, ~x[/fantasy_content/idontexist/text()]os) ==  nil
+    assert xpath(doc, ~x[/fantasy_content/idontexist/text()]oS) ==  nil
     assert xpath(doc, ~x[//total/text()]f) ==  204.68
   end
 


### PR DESCRIPTION
Fixes an issue for xpaths using optional strings where the returned
value would be an empty string ("") instead of nil.