### PR TITLE
Fix optional modifier for string entities

### DIFF
--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -430,10 +430,9 @@ defmodule SweetXml do
   end
 
   def xpath(parent, %SweetXpath{is_list: false, is_value: true, cast_to: string_type, is_optional: is_opt?} = spec) when string_type in [:string,:soft_string] do
-    spec = %SweetXpath{spec | is_list: true}
     get_current_entities(parent, spec)
-    |> Enum.map(&(_value(&1) |> to_cast(string_type, is_opt?)))
-    |> Enum.join
+    |> _value() 
+    |> to_cast(string_type, is_opt?)
     |> spec.transform_fun.()
   end
 

--- a/test/sweet_xml_test.exs
+++ b/test/sweet_xml_test.exs
@@ -56,6 +56,9 @@ defmodule SweetXmlTest do
     result = doc |> xpath(~x"//header/text()"s)
     assert result == "Content Header"
 
+    result = doc |> xpath(~x"//doesntexist/text()"so)
+    assert result == nil
+
     result = doc |> xpath(~x"//span[contains(@class,'badge')][@data-attr='first-half']/text()"l)
     assert result == ['One', 'Two', 'Three', 'Four', 'Five']
 


### PR DESCRIPTION
When using the optional `o` modifier and a node does not exist, xpath should return `nil` and not an empty string `""` or char list `''`.

The lines that I modified appeared to be added to avoid certain strings being split. All of the tests passed for me locally running Erlang v20.2.2, but the all of the the <20 versions failed on CI.

I did some digging and it looks to me that that was a bug that was fixed [here](https://github.com/erlang/otp/pull/1369) and released with xmerl [1.3.15](http://erlang.org/doc/apps/xmerl/notes.html#xmerl-1.3.15), which was released along with OTP [v20](https://github.com/erlang/otp/blob/master/otp_versions.table#L34).

I'm sure there is a desire for backwards compatibility for this library, but I'm not sure how to go about implementing that.

Any ideas?

Thanks! 