### PR TITLE
Fix depcrecation warning

### DIFF
--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -190,7 +190,7 @@ defmodule SweetXml do
   def sigil_x(path, modifiers \\ '') do
     %SweetXpath{
       path: String.to_charlist(path),
-      is_value: not ?e in modifiers,
+      is_value: ?e not in modifiers,
       is_list: ?l in modifiers,
       is_keyword: ?k in modifiers,
       is_optional: ?o in modifiers,


### PR DESCRIPTION
Fix this warning:

```
warning: "not expr1 in expr2" is deprecated. Instead use "expr1 not in expr2" if you require Elixir v1.5+, or "not(expr1 in expr2)
" if you have to support earlier Elixir versions                                                                                 
  lib/sweet_xml.ex:193
```
