### PR TITLE
Fix typo & wrong doc formatting

### DIFF
--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -267,7 +267,7 @@ defmodule SweetXml do
       ['l1', 'l2', 'l3', nil]
 
 
-  Becareful if you set `options[:discard]`. If any of the discarded tags is nested
+  Be careful if you set `options[:discard]`. If any of the discarded tags is nested
   inside a kept tag, you will not be able to access them.
 
   Examples:
@@ -536,19 +536,19 @@ defmodule SweetXml do
 
   ## Examples
 
-    iex> import SweetXml
-    iex> string_to_range = fn str ->
-    ...>     [first, last] = str |> String.split("-", trim: true) |> Enum.map(&String.to_integer/1)
-    ...>     first..last
-    ...>   end
-    iex> doc = "<weather><zone><name>north</name><wind-speed>5-15</wind-speed></zone></weather>"
-    iex> doc
-    ...> |> xpath(
-    ...>      ~x"//weather/zone"l,
-    ...>      name: ~x"//name/text()"s |> transform_by(&String.capitalize/1),
-    ...>      wind_speed: ~x"./wind-speed/text()"s |> transform_by(string_to_range)
-    ...>    )
-    [%{name: "North", wind_speed: 5..15}]
+      iex> import SweetXml
+      iex> string_to_range = fn str ->
+      ...>     [first, last] = str |> String.split("-", trim: true) |> Enum.map(&String.to_integer/1)
+      ...>     first..last
+      ...>   end
+      iex> doc = "<weather><zone><name>north</name><wind-speed>5-15</wind-speed></zone></weather>"
+      iex> doc
+      ...> |> xpath(
+      ...>      ~x"//weather/zone"l,
+      ...>      name: ~x"//name/text()"s |> transform_by(&String.capitalize/1),
+      ...>      wind_speed: ~x"./wind-speed/text()"s |> transform_by(string_to_range)
+      ...>    )
+      [%{name: "North", wind_speed: 5..15}]
   """
   def transform_by(%SweetXpath{}=sweet_xpath, fun) when is_function(fun) do
     %{sweet_xpath | transform_fun: fun}


### PR DESCRIPTION
Hi, thanks a lot for this wonderful package 😄 

While skimming through the doc I think I've found a typo and a malformed doc 🤔 

[Here](https://hexdocs.pm/sweet_xml/SweetXml.html#transform_by/2)'s the web page where I see the malformed doc, screenshot for completeness:

![Screen Shot 2019-06-22 at 12 27 06](https://user-images.githubusercontent.com/2248534/59962711-4d7f7400-94e9-11e9-89da-c76a0137fb8e.png)

I hope that my suggested changes fix it 😄 