### PR TITLE
Make xmlElement type not opaque

### DIFF
--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -139,7 +139,7 @@ defmodule SweetXml do
 
   @type doc :: (iodata | String.t | Enum.t)
   @type spec :: %SweetXpath{}
-  @opaque xmlElement :: record(:xmlElement)
+  @type xmlElement :: record(:xmlElement)
 
 
   @doc ~s"""


### PR DESCRIPTION
The opaqueness of SweetXml's `xmlElement` type has made it Dialyzer-incompatible with other xmerl-based libraries, such as [xmerl_c14n](https://hexdocs.pm/xmerl_c14n/XmerlC14n.html). Currently my code base has this line
```elixir
document
|> SweetXml.parse()
|> XmerlC14n.canonicalize!()
```
which produces the following Dialyzer error:
```
The call XmerlC14n.canonicalize!('Elixir.SweetXml':xmlElement()) contains an opaque term in 1st argument when a structured term of type binary() | {'xmlDocument',_} | {'xmlNamespace',_,_} | {'xmlComment',_,_,_,_} | {'xmlDecl',_,_,_,_} | {'xmlNsNode',_,_,_,_} | {'xmlPI',_,_,_,_} | {'xmlText',_,_,_,_,_} | {'xmlAttribute',_,_,_,_,_,_,_,_,_} | {'xmlElement',_,_,_,_,_,_,_,_,_,_,_} is expected}. (lsp)
```