### PR TITLE
Correct error handling

### DIFF
--- a/lib/sweet_xml/options.ex
+++ b/lib/sweet_xml/options.ex
@@ -2,15 +2,15 @@ defmodule SweetXml.Options do
   @moduledoc false
 
   def handle_dtd(:all) do
-    fn _ -> [] end
+    fn _, _ -> [] end
   end
   def handle_dtd(:none) do
-    fn ets ->
-      handle_dtd(:internal_only).(ets) ++ handle_dtd(only: []).(ets)
+    fn ets, exception_module ->
+      handle_dtd(:internal_only).(ets, exception_module) ++ handle_dtd(only: []).(ets, exception_module)
     end
   end
   def handle_dtd(:internal_only) do
-    fn _ ->
+    fn _, _ ->
       [fetch_fun: fn _, _ -> {:error, "no external entity allowed"} end]
     end
   end
@@ -18,7 +18,7 @@ defmodule SweetXml.Options do
     handle_dtd(only: [entity])
   end
   def handle_dtd(only: entities) when is_list(entities) do
-    fn ets ->
+    fn ets, exception_module ->
       read = fn
         context, name, state ->
           ets = :xmerl_scan.rules_state(state)
@@ -37,7 +37,8 @@ defmodule SweetXml.Options do
                   [] -> :ets.insert(ets, {{context, name}, value})
                   _ -> :ok
                 end
-              false -> raise("DTD not allowed: #{name}")
+              false ->
+                raise exception_module, message: "DTD not allowed: #{name}"
             end
             state
 

--- a/test/files/invalid.xml
+++ b/test/files/invalid.xml
@@ -1,0 +1,44 @@
+<?xml version="1.05" encoding="UTF-8"?>
+<game>
+  <matchups>
+    <matchup winner-id="1">
+      <name>Match One</name>
+      <teams>
+        <team>
+          <id>1</id>
+          <name>Team One</name>
+        </team>
+        <team>
+          <id>2</id>
+          <name>Team Two</name>
+        </team>
+      </teams>
+    </matchup>
+    <matchup winner-id="2">
+      <name>Match Two</name>
+      <teams>
+        <team>
+          <id>2</id>
+          <name>Team Two</name>
+        </team>
+        <team>
+          <id>3</id>
+          <name>Team Three</name>
+        </team>
+      </teams>
+    </matchup>
+    <matchup winner-id="1">
+      <name>Match Three</name>
+      <teams>
+        <team>
+          <id>1</id>
+          <name>Team One</name>
+        </team>
+        <team>
+          <id>3</id>
+          <name>Team & Three</name>
+        </team>
+      </teams>
+    </matchup>
+  </matchups>
+</game>

--- a/test/sweet_xml_stream_test.exs
+++ b/test/sweet_xml_stream_test.exs
@@ -106,5 +106,14 @@ defmodule SweetXmlStreamTest do
         |> Stream.run()
       end
     end
+
+    test "internal only" do
+      assert_raise SweetXml.DTDError, "no external entity allowed", fn ->
+        "test/files/xxe.xml"
+        |> File.stream!()
+        |> SweetXml.stream_tags!(:result, dtd: :internal_only)
+        |> Stream.run
+      end
+    end
   end
 end


### PR DESCRIPTION
Make it possible to handle XML errors in streams.

- Do not use both monitor and link for parser process
- ~~Do not make a user enable `trap_exit` for handling an error~~
- ~~An item now could be either `{:ok, item}` or `{:error, reason}`~~
- Introduces custom exceptions as was discussed [here](https://github.com/kbrw/sweet_xml/pull/86#issuecomment-958992742)
- Introduces new functions `stream!` and `stream_tags!` as was discussed [here](https://github.com/kbrw/sweet_xml/pull/86#issuecomment-958994713) for the backward compatibility sake