### PR TITLE
Fix typos and prettify md/yaml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@
 
 ### Changed
 
-* Handling the option `{:rules, _}` ourselve, as well as partially the option `{:rules, _, _, _}`.
+* Handling the option `{:rules, _}` ourselves, as well as partially the option `{:rules, _, _, _}`.
   When nothing is given, a new table is created, and destroyed after.
   If a table is given, and a DTD option is chosen, the table is reused for the DTD handling.
-  If a custom `{:rules, _, _, _}` is given, and a restrictive DTD option is chosen, the custome rule will be overriden.
+  If a custom `{:rules, _, _, _}` is given, and a restrictive DTD option is chosen, the custome rule will be overridden.
   Because of this mutual exclusivity (reconciling the behaviors is not possible via composition), it is recommended that you handle the DTD
   problem by yourself. You can see the issue `#71` for ideas.
   See the issue `#41` for more details on why this change happened. (Ets leaks.)

--- a/README.md
+++ b/README.md
@@ -489,5 +489,5 @@ SweetXml source code is licensed under the [MIT License](https://github.com/kbrw
 # CONTRIBUTING
 
 Hi, and thank you for wanting to contribute.
-Please refer to the centralized informations available at: https://github.com/kbrw#contributing
+Please refer to the centralized information available at: https://github.com/kbrw#contributing
 

--- a/lib/sweet_xml/options.ex
+++ b/lib/sweet_xml/options.ex
@@ -1,6 +1,6 @@
 defmodule SweetXml.Options do
   ### WARNING:
-  # This is an intenal api, use at your own risk.
+  # This is an internal api, use at your own risk.
 
   @moduledoc false
 
@@ -104,7 +104,7 @@ defmodule SweetXml.Options do
 
           {[[_]], _opts} ->
             require Logger
-            _ = Logger.warning("rules opt will be overriden because of the dtd option")
+            _ = Logger.warning("rules opt will be overridden because of the dtd option")
             opts = opts ++ dtd_opts ++ [rules: ets]
             {opts, {:cleanup, ets}}
         end

--- a/test/issue_41_test.exs
+++ b/test/issue_41_test.exs
@@ -7,7 +7,7 @@ defmodule Issue41Test do
     # Warning ! Sensitive to async tests.
     assert capture_log(fn ->
       SweetXml.parse("<tag></tag>", [rules, dtd: :none])
-    end) =~ "rules opt will be overriden because of the dtd option"
+    end) =~ "rules opt will be overridden because of the dtd option"
   end
 
   test "keeps our rules/1" do


### PR DESCRIPTION
Resolved via these commands:

    codespell -L ist,tring,som
    prettier -w .