### PR TITLE
Fix charlist warnings for Elixir 1.17

### DIFF
--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -223,7 +223,7 @@ defmodule SweetXml do
 
     * `~x"//some/path"il` - integer list
   """
-  def sigil_x(path, modifiers \\ '') do
+  def sigil_x(path, modifiers \\ ~c"") do
     %SweetXpath{
       path: String.to_charlist(path),
       is_value: not(?e in modifiers),
@@ -293,7 +293,7 @@ defmodule SweetXml do
     parsed_doc
   end
   def do_parse(doc_enum, options) do
-    {parsed_doc, _} = :xmerl_scan.string('', options ++ continuation_opts(doc_enum))
+    {parsed_doc, _} = :xmerl_scan.string(~c"", options ++ continuation_opts(doc_enum))
     parsed_doc
   end
 
@@ -470,7 +470,7 @@ defmodule SweetXml do
 
       {opts, do_after} = SweetXml.Options.set_up(opts, RuntimeError)
 
-      pid = spawn_link fn -> :xmerl_scan.string('', opts ++ continuation_opts(doc, waiter)) end
+      pid = spawn_link fn -> :xmerl_scan.string(~c"", opts ++ continuation_opts(doc, waiter)) end
       {ref, pid, Process.monitor(pid), do_after}
     end, fn {ref, pid, monref, do_after} = acc ->
       receive do
@@ -513,7 +513,7 @@ defmodule SweetXml do
 
       {opts, do_after} = SweetXml.Options.set_up(opts, SweetXml.DTDError)
 
-      {pid, monref} = spawn_monitor(fn -> :xmerl_scan.string('', opts ++ continuation_opts(doc, waiter)) end)
+      {pid, monref} = spawn_monitor(fn -> :xmerl_scan.string(~c"", opts ++ continuation_opts(doc, waiter)) end)
       {ref, pid, monref, do_after}
     end, fn {ref, pid, monref, do_after} = acc ->
       receive do


### PR DESCRIPTION
Hello 👋 

The changes address warnings introduced by Elixir 1.17 regarding charlists usage:

```elixir
==> sweet_xml
Compiling 2 files (.ex)
     warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
     │
 226 │   def sigil_x(path, modifiers \\ '') do
     │                                  ~
     │
     └─ lib/sweet_xml.ex:226:34

     warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
     │
 296 │     {parsed_doc, _} = :xmerl_scan.string('', options ++ continuation_opts(doc_enum))
     │                                          ~
     │
     └─ lib/sweet_xml.ex:296:42

     warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
     │
 473 │       pid = spawn_link fn -> :xmerl_scan.string('', opts ++ continuation_opts(doc, waiter)) end
     │                                                 ~
     │
     └─ lib/sweet_xml.ex:473:49

     warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
     │
 516 │       {pid, monref} = spawn_monitor(fn -> :xmerl_scan.string('', opts ++ continuation_opts(doc, waiter)) end)
     │                                                              ~
     │
     └─ lib/sweet_xml.ex:516:62
```

Please let me know if I missed something 🙏 