### PR TITLE
fix: use map update to avoid struct type warning in add_namespace/3

### DIFF
--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -255,7 +255,7 @@ defmodule SweetXml do
   end
 
   def add_namespace(%SweetXpath{} = xpath, prefix, uri) do
-    %SweetXpath{
+    %{
       xpath
       | namespaces: [
           {to_charlist(prefix), to_charlist(uri)}


### PR DESCRIPTION
Elixir 1.19+ type checker warns when using struct update syntax with a dynamic type. Since the function head already pattern matches on %SweetXpath{}, we can safely use map update syntax instead.