### PR TITLE
Fix SweetXpath namespace struct update warning

### DIFF
--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -255,13 +255,7 @@ defmodule SweetXml do
   end
 
   def add_namespace(%SweetXpath{} = xpath, prefix, uri) do
-    %SweetXpath{
-      xpath
-      | namespaces: [
-          {to_charlist(prefix), to_charlist(uri)}
-          | xpath.namespaces
-        ]
-    }
+    %{xpath | namespaces: [{to_charlist(prefix), to_charlist(uri)} | xpath.namespaces]}
   end
 
   @doc """


### PR DESCRIPTION
Use map update syntax in add_namespace/3 to avoid the compiler typing warning on newer
  Elixir versions without changing behaviour.